### PR TITLE
Run the PowerShell argv tests off-Windows by stubbing CREATE_NO_WINDOW

### DIFF
--- a/tests/test_launch_arguments.py
+++ b/tests/test_launch_arguments.py
@@ -103,6 +103,13 @@ def fixture_captured_ps_command(monkeypatch):
 
     monkeypatch.setattr(core_functions.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(core_functions, "log_message", lambda *a, **k: None)
+    # CREATE_NO_WINDOW exists only on Windows, and the real function reads it
+    # while building the Popen call - before the stub above can fire. Supplying
+    # it keeps these tests live off-Windows; the stubbed Popen never consumes
+    # the value, so Windows behavior is untouched.
+    monkeypatch.setattr(
+        core_functions.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False
+    )
 
     def run(arguments=None):
         captured.clear()


### PR DESCRIPTION
## What this is

A 7-line, test-only change. The `captured_ps_command` fixture in `tests/test_launch_arguments.py` now injects `subprocess.CREATE_NO_WINDOW` (`0x08000000`, the real Windows value) with `raising=False`, so the two tests that pin the `-Arguments` clause of the PowerShell command run on Linux instead of erroring. No production code is touched.

## Why this shape

On Linux those two tests failed with a confusing `KeyError('argv')`: `start_process_with_powershell` reads `subprocess.CREATE_NO_WINDOW` while building the `Popen` call, before the fixture's stub can fire, and the surrounding `except Exception` swallows the real error. The first attempt guarded them with `skipif`, per the handoff notes — the adversarial review seat rejected that with a measured case: with the skip in place, deleting the `-Arguments` clause left the whole suite green on Linux, which is the only platform where the pre-push gate runs (there is no CI). Both seats independently verified the fixture stub as the fix that keeps the tests live everywhere; the stubbed `Popen` discards `creationflags`, so the injected value is never consumed.

## Verified (all on the Linux workspace, output quoted as observed)

- `python -m pytest -q` → `46 passed, 3 skipped in 0.37s` (remaining skips: 2 empty-checkout config characterizations, 1 real-PowerShell end-to-end test).
- Mutation tests, both directions: deleting the `if arguments:` clause in `core_functions.py` fails exactly `test_arguments_reach_the_command_handed_to_powershell` (`1 failed, 19 passed, 1 skipped`); making the clause unconditional fails exactly `test_no_arguments_clause_when_the_entry_has_none`. Tree restored and re-verified green after each.
- `pylint tests/test_launch_arguments.py` → 9.52/10, message set identical to `main`.
- Monkeypatch teardown measured clean: the attribute is absent again after each test, so the `hasattr` skipif on the real-PowerShell test is unaffected.
- Two-reviewer gate: QA seat APPROVE, adversarial seat APPROVE (second round, after the first-round skipif version was rejected). One non-blocking NOTE: the new setattr line is 80 chars, one E501 in a file with 34 pre-existing ones, outside the lint gate.

## Not verified

- Not run on Windows or the cabinet. The Windows claim — that overwriting `CREATE_NO_WINDOW` with its own documented value changes nothing — is value-equality reasoning (the repo itself uses the `0x08000000` literal in `start_streaming.py:98`), not observation.

## What to check on the cabinet

Just `python -m pytest` after pulling: expect 49 passed as before, now including these two tests. A failure in either would mean the injected constant interacts badly with real Windows `subprocess`, which nothing predicts. Nothing on the boot or launch path changes — production code is untouched, so no runtime behavior differs on next boot.